### PR TITLE
Fix(scoring): multichoice questions bounds

### DIFF
--- a/src/utils/calculatePoliticianPossibleScores.ts
+++ b/src/utils/calculatePoliticianPossibleScores.ts
@@ -28,8 +28,8 @@ export const calculatePoliticianFactor = (survey: Survey): SurveyPoliticiansPoss
                         : acc[politicianId].maxPossibleScore,
                   }
                 : {
-                    minPossibleScore: score * Importance.IMPORTANT,
-                    maxPossibleScore: score * Importance.IMPORTANT,
+                    minPossibleScore: 0,
+                    maxPossibleScore: 0,
                   },
             }),
             {},


### PR DESCRIPTION
In case of a multichoice question, we must initialize the score bounds to 0 because we sum the answer choices rather than taking the min/max